### PR TITLE
#11: Some config variables should be state variables

### DIFF
--- a/config/statistics.settings.json
+++ b/config/statistics.settings.json
@@ -4,17 +4,12 @@
     "count_content_views_ajax": 0,
     "enable_access_log": 0,
     "flush_accesslog_timer": 259200,
-    "day_timestamp": "",
-    "week_timestamp": "",
-    "month_timestamp": "",
-    "year_timestamp": "",
     "block_top_day_num": 0,
     "block_top_week_num": 0,
     "block_top_month_num": 0,
     "block_top_year_num": 0,
     "block_top_all_num": 0,
     "block_top_last_num": 0,
-    "cron_views_scale": 0,
     "count_node_types": [],
     "node_count_excluded_roles": {
         "administrator": "administrator"

--- a/statistics.install
+++ b/statistics.install
@@ -174,3 +174,27 @@ function statistics_update_1000() {
 function statistics_update_last_removed() {
   return 7000;
 }
+
+/**
+ * Move some regularly changing config variables to state.
+ */
+function statistics_update_1002() {
+  $config = config('statistics.settings');
+
+  state_set('statistics_cron_views_scale', $config->get('cron_views_scale'));
+  $config->clear('cron_views_scale');
+
+  state_set('statistics_day_timestamp', $config->get('day_timestamp'));
+  $config->clear('day_timestamp');
+
+  state_set('statistics_week_timestamp', $config->get('week_timestamp'));
+  $config->clear('week_timestamp');
+
+  state_set('statistics_month_timestamp', $config->get('month_timestamp'));
+  $config->clear('month_timestamp');
+
+  state_set('statistics_year_timestamp', $config->get('year_timestamp'));
+  $config->clear('year_timestamp');
+
+  $config->save();
+}

--- a/statistics.module
+++ b/statistics.module
@@ -219,7 +219,6 @@ function statistics_user_delete($account) {
  * Implements hook_cron().
  */
 function statistics_cron() {
-  $config = config('statistics.settings');
   $timestamps = array(
     'year' => 86400*365,
     'month' => 86400*30,
@@ -228,19 +227,19 @@ function statistics_cron() {
   );
 
   foreach ($timestamps as $timestamp => $interval) {
-    $stamp = $timestamp . '_timestamp';
-    $statistics_timestamp = $config->get($stamp);
+    $stamp = 'statistics_' . $timestamp . '_timestamp';
+    $statistics_timestamp = state_get($stamp);
     if ((REQUEST_TIME - $statistics_timestamp) >= $interval) {
       // Reset day counts.
       db_update('node_counter')
         ->fields(array($timestamp . 'count' => 0))
         ->execute();
-      $config->set($stamp, REQUEST_TIME);
+      state_set($stamp, REQUEST_TIME);
     }
   }
-  $config->save();
 
   // Clean up expired access logs (if applicable).
+  $config = config('statistics.settings');
   if ($config->get('flush_accesslog_timer') > 0) {
     db_delete('accesslog')
       ->condition('timestamp', REQUEST_TIME - $config->get('flush_accesslog_timer'), '<')
@@ -249,7 +248,7 @@ function statistics_cron() {
 }
 
 /**
- * Returns the most viewed content of all time, various time periods, or the 
+ * Returns the most viewed content of all time, various time periods, or the
  * last-viewed node.
  *
  * @param $dbfield
@@ -257,9 +256,9 @@ function statistics_cron() {
  *   - 'totalcount': Integer that shows the top viewed content of all time.
  *   - 'daycount': Integer that shows the top viewed content for today.
  *   - 'weekcount': Integer that shows the top viewed content for the week.
- *   - 'monthcount': Integer that shows the top viewed content for the last 30 
+ *   - 'monthcount': Integer that shows the top viewed content for the last 30
  *     days.
- *   - 'dayearcount': Integer that shows the top viewed content for the last 
+ *   - 'dayearcount': Integer that shows the top viewed content for the last
  *     365 days.
  *   - 'timestamp': Integer that shows only the last viewed node.
  * @param $dbrows
@@ -300,7 +299,7 @@ function statistics_title_list($dbfield, $dbrows) {
  *   An associative array containing:
  *   - totalcount: Integer for the total number of times the node has been
  *     viewed.
- *   - daycount, weekcount, monthcount, yearcount: Integers for the total 
+ *   - daycount, weekcount, monthcount, yearcount: Integers for the total
  *     number of times the node has been viewed for time intervals.
  *     "today". For the daycount to be reset, cron must be enabled.
  *   - timestamp: Integer for the timestamp of when the node was last viewed.
@@ -467,7 +466,7 @@ function statistics_ranking() {
         ),
         // Inverse law that maps the highest view count on the site to 1 and 0 to 0.
         'score' => '2.0 - 2.0 / (1.0 + node_counter.totalcount * CAST(:scale AS DECIMAL))',
-        'arguments' => array(':scale' => $config->get('node_cron_views_scale')),
+        'arguments' => array(':scale' => state_get('statistics_cron_views_scale')),
       ),
     );
   }
@@ -477,7 +476,7 @@ function statistics_ranking() {
  * Implements hook_update_index().
  */
 function statistics_update_index() {
-  config_set('statistics.settings', 'node_cron_views_scale', 1.0 / max(1, db_query('SELECT MAX(totalcount) FROM {node_counter}')->fetchField()));
+  state_set('statistics_cron_views_scale', 1.0 / max(1, db_query('SELECT MAX(totalcount) FROM {node_counter}')->fetchField()));
 }
 
 

--- a/statistics.test
+++ b/statistics.test
@@ -427,8 +427,9 @@ class StatisticsAdminTestCase extends BackdropWebTestCase {
   function testExpiredLogs() {
     config_set('statistics.settings', 'enable_access_log', 1);
     config_set('statistics.settings', 'count_content_views', 1);
-    config_set('statistics.settings', 'day_timestamp', 8640000);
     config_set('statistics.settings', 'flush_accesslog_timer', 1);
+
+    state_set('statistics_day_timestamp', 8640000);
 
     $this->backdropGet('node/' . $this->test_node->nid);
     $this->backdropGet('node/' . $this->test_node->nid);


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/statistics/issues/11.

This PR moves some config variables into state and fixes an inconsistency with respect to the variable `cron_views_scale`. It creates `hook_update_1002()`, so is intended to be applied after [PR 10](https://github.com/backdrop-contrib/statistics/pull/10), which creates `hook_update_1001()`.