### PR TITLE
fixes #27: Group all reports in a single report's menu entry

### DIFF
--- a/statistics.admin.inc
+++ b/statistics.admin.inc
@@ -16,6 +16,7 @@
  *   A render array containing information about the most recent hits.
  */
 function statistics_recent_hits() {
+  backdrop_add_library('system', 'backdrop.ajax');
   $header = array(
     array('data' => t('Timestamp'), 'field' => 'a.timestamp', 'sort' => 'desc'),
     array('data' => t('Page'), 'field' => 'a.path'),
@@ -34,11 +35,20 @@ function statistics_recent_hits() {
   $result = $query->execute();
   $rows = array();
   foreach ($result as $log) {
+    $options = array(
+      'attributes' => array(
+        'class' => array(
+          'use-ajax'),
+        'data-dialog' => 'true',
+        'data-dialog-options' => json_encode(array('width' => 700, 'dialogClass' => 'project-dialog')),
+      )
+    );
     $rows[] = array(
       array('data' => format_date($log->timestamp, 'short'), 'class' => array('nowrap')),
       _statistics_format_item($log->title, $log->path),
       theme('username', array('account' => $log)),
-      l(t('details'), "admin/reports/access/$log->aid"));
+      l(t('details'), "admin/reports/statistics/hits/$log->aid", $options)
+    );
   }
 
   $build['statistics_table'] = array(
@@ -147,9 +157,9 @@ function statistics_top_visitors() {
   $destination = backdrop_get_destination();
   foreach ($result as $account) {
     $rows[] = array(
-      $account->hits, 
-      ($account->uid ? theme('username', array('account' => $account)) : $account->hostname), 
-      format_interval(round($account->total / 1000)), 
+      $account->hits,
+      ($account->uid ? theme('username', array('account' => $account)) : $account->hostname),
+      format_interval(round($account->total / 1000)),
     );
   }
 

--- a/statistics.module
+++ b/statistics.module
@@ -123,41 +123,50 @@ function statistics_node_view($node, $view_mode) {
  * Implements hook_menu().
  */
 function statistics_menu() {
-  $items['admin/reports/hits'] = array(
-    'title' => 'Recent hits',
-    'description' => 'View pages that have recently been visited.',
+  $items['admin/reports/statistics'] = array(
+    'title' => 'Statistics',
+    'description' => 'View all reports by the statistics module.',
     'page callback' => 'statistics_recent_hits',
     'access arguments' => array('access statistics'),
     'file' => 'statistics.admin.inc',
   );
-  $items['admin/reports/pages'] = array(
+  $items['admin/reports/statistics/hits'] = array(
+    'title' => 'Recent hits',
+    'description' => 'View pages that have recently been visited.',
+    'type' => MENU_DEFAULT_LOCAL_TASK,
+    'weight' => -20,
+  );
+  $items['admin/reports/statistics/pages'] = array(
     'title' => 'Top pages',
     'description' => 'View pages that have been hit frequently.',
     'page callback' => 'statistics_top_pages',
     'access arguments' => array('access statistics'),
     'weight' => 1,
     'file' => 'statistics.admin.inc',
+    'type' => MENU_LOCAL_TASK,
   );
-  $items['admin/reports/visitors'] = array(
+  $items['admin/reports/statistics/visitors'] = array(
     'title' => 'Top visitors',
     'description' => 'View visitors that hit many pages.',
     'page callback' => 'statistics_top_visitors',
     'access arguments' => array('access statistics'),
     'weight' => 2,
     'file' => 'statistics.admin.inc',
+    'type' => MENU_LOCAL_TASK,
   );
-  $items['admin/reports/referrers'] = array(
+  $items['admin/reports/statistics/referrers'] = array(
     'title' => 'Top referrers',
     'description' => 'View top referrers.',
     'page callback' => 'statistics_top_referrers',
     'access arguments' => array('access statistics'),
     'file' => 'statistics.admin.inc',
+    'type' => MENU_LOCAL_TASK,
   );
-  $items['admin/reports/access/%'] = array(
+  $items['admin/reports/statistics/hits/%'] = array(
     'title' => 'Details',
     'description' => 'View access log.',
     'page callback' => 'statistics_access_log',
-    'page arguments' => array(3),
+    'page arguments' => array(4),
     'access arguments' => array('access statistics'),
     'file' => 'statistics.admin.inc',
   );

--- a/statistics.pages.inc
+++ b/statistics.pages.inc
@@ -40,6 +40,107 @@ function statistics_node_tracker() {
         array('data' => format_date($log->timestamp, 'short'), 'class' => array('nowrap')),
         _statistics_link($log->url),
         theme('username', array('account' => $log)),
+        l(t('details'), "admin/reports/statistics/hits/$log->aid"),
+      );
+    }
+
+    backdrop_set_title($node->title);
+    $build['statistics_table'] = array(
+      '#theme' => 'table',
+      '#header' => $header,
+      '#rows' => $rows,
+      '#empty' => t('No statistics available.'),
+    );
+    $build['statistics_pager'] = array('#theme' => 'pager');
+    return $build;
+  }
+  return MENU_NOT_FOUND;
+}
+
+/**
+ * Page callback: Displays statistics for a user.
+ *
+ * @return array
+ *   A render array containing user statistics. If information for the user was
+ *   not found, this will deliver a page not found error via backdrop_not_found().
+ */
+function statistics_user_tracker() {
+  if ($account = user_load(arg(1))) {
+
+    $header = array(
+        array('data' => t('Timestamp'), 'field' => 'timestamp', 'sort' => 'desc'),
+        array('data' => t('Page'), 'field' => 'path'),
+        array('data' => t('Operations')));
+    $query = db_select('accesslog', 'a', array('target' => 'slave'))->extend('PagerDefault')->extend('TableSort');
+    $query
+      ->fields('a', array('aid', 'timestamp', 'path', 'title'))
+      ->condition('uid', $account->uid)
+      ->limit(30)
+      ->orderByHeader($header);
+
+    $result = $query->execute();
+    $rows = array();
+    foreach ($result as $log) {
+      $rows[] = array(
+        array('data' => format_date($log->timestamp, 'short'), 'class' => array('nowrap')),
+        _statistics_format_item($log->title, $log->path),
+        l(t('details'), "admin/reports/statistics/hits/$log->aid"));
+    }
+
+    backdrop_set_title(format_username($account));
+    $build['statistics_table'] = array(
+      '#theme' => 'table',
+      '#header' => $header,
+      '#rows' => $rows,
+      '#empty' => t('No statistics available.'),
+    );
+    $build['statistics_pager'] = array('#theme' => 'pager');
+    return $build;
+  }
+  return MENU_NOT_FOUND;
+}
+<?php
+
+/**
+ * @file
+ * User page callbacks for the Statistics module.
+ */
+
+/**
+ * Page callback: Displays statistics for a node.
+ *
+ * @return
+ *   A render array containing node statistics. If information for the node was
+ *   not found, this will deliver a page not found error via backdrop_not_found().
+ */
+function statistics_node_tracker() {
+  if ($node = node_load(arg(1))) {
+
+    $header = array(
+        array('data' => t('Time'), 'field' => 'a.timestamp', 'sort' => 'desc'),
+        array('data' => t('Referrer'), 'field' => 'a.url'),
+        array('data' => t('User'), 'field' => 'u.name'),
+        array('data' => t('Operations')));
+
+    $query = db_select('accesslog', 'a', array('target' => 'slave'))->extend('PagerDefault')->extend('TableSort');
+    $query->join('users', 'u', 'a.uid = u.uid');
+
+    $query
+      ->fields('a', array('aid', 'timestamp', 'url', 'uid'))
+      ->fields('u', array('name'))
+      ->condition(db_or()
+        ->condition('a.path', 'node/' . $node->nid)
+        ->condition('a.path', 'node/' . $node->nid . '/%', 'LIKE'))
+      ->limit(30)
+      ->orderByHeader($header);
+
+    $result = $query->execute();
+    $rows = array();
+    foreach ($result as $log) {
+      $rows[] = array(
+        array('data' => format_date($log->timestamp, 'short'), 'class' => array('nowrap')),
+        _statistics_link($log->url),
+        theme('username', array('account' => $log)),
         l(t('details'), "admin/reports/access/$log->aid"),
       );
     }

--- a/statistics.test
+++ b/statistics.test
@@ -204,7 +204,7 @@ class StatisticsReportsTestCase extends StatisticsTestCase {
    * Verifies that 'Details' page renders properly and displays the added hit.
    */
   function testDetails() {
-    $this->backdropGet('admin/reports/access/1');
+    $this->backdropGet('admin/reports/statistics/hits/1');
     $this->assertText('test', 'Hit title found.');
     $this->assertText('node/1', 'Hit URL found.');
     $this->assertText('Anonymous', 'Hit user found.');


### PR DESCRIPTION
fixes #27 

Also, show hit details in a dialog window. Changed menu entry `admin/reports/access/%` to `admin/reports/statistics/hits/%`.

This is how it shows:

![Statistics___Ona_Codinenca_-_Vivaldi](https://github.com/user-attachments/assets/ebe7e272-1c63-48f9-bd63-401e7df2c632)
